### PR TITLE
fix timer logic

### DIFF
--- a/frontend/src/components/modules/GameInterface/GameInterface.tsx
+++ b/frontend/src/components/modules/GameInterface/GameInterface.tsx
@@ -175,6 +175,10 @@ const GameInterface: React.FC = () => {
   const handlePointShowing = async (): Promise<void> => {
     setOpen(false);
     if (matchId !== undefined) {
+      if (isTimerRunning) {
+        setIsTimerRunning((prevIsTimerRunning) => !prevIsTimerRunning);
+        await apiTimerRequest(matchId);
+      }
       await apiPointRequest(matchId, pointRequest);
     }
   };


### PR DESCRIPTION
pysäyttää timerin kun lisätään piste kellon pyöriessä. korjaa sen että kello ei ala alusta ja sen että kello ei jää pyörimään matsin päätyttyä