### PR TITLE
Feature/past tournaments view

### DIFF
--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -13,7 +13,7 @@
     "unexpected_error_happened": "An unexpected error occurred!",
     "sign_up_success": "Successfully signed up for tournament: ",
     "minimum_players_error": "Minimum amount of players is ",
-  	"creations_success": "Tournament {{name}} created successfully",
+    "creations_success": "Tournament {{name}} created successfully",
     "invalid_tournament_error": "This tournament seems to be invalid. Contact {{organizerEmail}} for more information about this tournament.",
     "session_expired_message": "Session Expired: Your login session has expired for security reasons. Please log in again.",
     "tournament_info_not_found": "No data was found for this tournament. Close this to go back to the previous view.",
@@ -164,5 +164,13 @@
     "openSettingsTooltip": "Open settings",
     "about": "About",
     "privacy_policy": "Privacy Policy"
+  },
+  "sorting": {
+    "orderBy": "Order By: ",
+    "mostRecent": "Most recent",
+    "oldest": "Oldest",
+    "name": "Name A-Ö",
+    "nameDesc": "Name Ö-Ä",
+    "location": "Location"
   }
 }

--- a/frontend/locales/fi.json
+++ b/frontend/locales/fi.json
@@ -164,5 +164,13 @@
     "openSettingsTooltip": "Avaa asetukset",
     "about": "About-sivu",
     "privacy_policy": "Yksityisyyskäytäntö"
+  },
+  "sorting": {
+    "orderBy": "Järjestä: ",
+    "mostRecent": "Uusin",
+    "oldest": "Vanhin",
+    "name": "Nimi A-Ö",
+    "nameDesc": "Nimi Ö-Ä",
+    "location": "Sijainti"
   }
 }

--- a/frontend/src/components/modules/Tournaments/PastTournamentMatches.tsx
+++ b/frontend/src/components/modules/Tournaments/PastTournamentMatches.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useParams } from "react-router-dom";
 import { useTournaments } from "context/TournamentsContext";
-import type { User, Match, MatchPlayer } from "types/models";
+import type { User, Match, MatchPoint, MatchPlayer } from "types/models";
 import { Grid, Typography, Paper } from "@mui/material";
 
 const PastTournamentMatches: React.FC = () => {
@@ -36,17 +36,24 @@ const PastTournamentMatches: React.FC = () => {
         let player1Points = 0;
         let player2Points = 0;
 
-        /* this is a stub, only points for wins are taken into account.
-          1 pt for ties has to be added once logic for them works */
-        if (match.winner === match.players[0].id) {
-          player1Points += 3;
-        } else if (match.winner === match.players[1].id) {
-          player2Points += 3;
-        }
-        /* insert tie here
-           player1Points += 1;
-           player2Points += 1; 
-         } */
+        match.players[0].points.forEach((point: MatchPoint) => {
+          if (point.type === "hansoku") {
+            player2Points += 0.5;
+          } else {
+            player1Points += 1;
+          }
+        });
+
+        match.players[1].points.forEach((point: MatchPoint) => {
+          if (point.type === "hansoku") {
+            player1Points += 0.5;
+          } else {
+            player2Points += 1;
+          }
+        });
+
+        player1Points = Math.floor(player1Points);
+        player2Points = Math.floor(player2Points);
 
         return (
           <Paper key={index} elevation={2} style={{ padding: "10px" }}>

--- a/frontend/src/components/modules/Tournaments/PastTournamentMatches.tsx
+++ b/frontend/src/components/modules/Tournaments/PastTournamentMatches.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+import { useParams } from "react-router-dom";
+import { useTournaments } from "context/TournamentsContext";
+import type { User, Match, MatchPlayer } from "types/models";
+import { Grid, Typography, Paper } from "@mui/material";
+
+const PastTournamentMatches: React.FC = () => {
+  const { tournamentId } = useParams();
+  const { past } = useTournaments();
+  const selectedTournament = past.find(
+    (tournament) => tournament.id === tournamentId
+  );
+
+  if (selectedTournament === null || selectedTournament === undefined) {
+    return <div>Tournament not found.</div>;
+  }
+
+  return (
+    <div>
+      <Typography variant="h4" sx={{ marginBottom: 4 }}>
+        {selectedTournament.name}
+      </Typography>
+      <Typography variant="h6" sx={{ marginBottom: 4 }}>
+        {selectedTournament.type}
+      </Typography>
+
+      {/* Fetch match player names */}
+      {selectedTournament.matchSchedule.map((match: Match, index: number) => {
+        const matchPlayers = match.players.map((player: MatchPlayer) => {
+          const user: User | undefined = selectedTournament.players.find(
+            (tournamentPlayer: User) => tournamentPlayer.id === player.id
+          );
+          return `${user?.firstName ?? "Unknown"} ${user?.lastName ?? "User"}`;
+        });
+
+        let player1Points = 0;
+        let player2Points = 0;
+
+        /* this is a stub, only points for wins are taken into account.
+          1 pt for ties has to be added once logic for them works */
+        if (match.winner === match.players[0].id) {
+          player1Points += 3;
+        } else if (match.winner === match.players[1].id) {
+          player2Points += 3;
+        }
+        /* insert tie here
+           player1Points += 1;
+           player2Points += 1; 
+         } */
+
+        return (
+          <Paper key={index} elevation={2} style={{ padding: "10px" }}>
+            <Grid container justifyContent="center" rowSpacing={2}>
+              <Grid item xs={2}>
+                <Typography variant="body1">{matchPlayers[0]}</Typography>
+              </Grid>
+              <Grid item xs={2}>
+                <Typography variant="body1">
+                  {player1Points} - {player2Points}
+                </Typography>
+              </Grid>
+              <Grid item xs={2}>
+                <Typography variant="body1">{matchPlayers[1]}</Typography>
+              </Grid>
+            </Grid>
+          </Paper>
+        );
+      })}
+    </div>
+  );
+};
+
+export default PastTournamentMatches;

--- a/frontend/src/components/modules/Tournaments/TournamentListing/TournamentCard.tsx
+++ b/frontend/src/components/modules/Tournaments/TournamentListing/TournamentCard.tsx
@@ -62,9 +62,9 @@ const TournamentCard: React.FC<TournamentCardProps> = ({
           )}
           {type === "past" && (
             <Typography color="text.secondary">
-              {tournament.location},
-              {new Date(tournament.startDate).toLocaleDateString("fi")} -
-              {new Date(tournament.endDate).toLocaleDateString("fi")}
+              {`${tournament.location}, 
+              ${new Date(tournament.startDate).toLocaleDateString("fi")} -
+              ${new Date(tournament.endDate).toLocaleDateString("fi")}`}
             </Typography>
           )}
         </CardContent>

--- a/frontend/src/components/modules/Tournaments/TournamentListing/TournamentCard.tsx
+++ b/frontend/src/components/modules/Tournaments/TournamentListing/TournamentCard.tsx
@@ -31,7 +31,11 @@ const TournamentCard: React.FC<TournamentCardProps> = ({
     <Card component="main" sx={{ position: "relative" }}>
       <CardActionArea
         onClick={() => {
-          navigate(tournament.id);
+          if (type === "past") {
+            navigate(`past-tournament/${tournament.id}`);
+          } else {
+            navigate(tournament.id);
+          }
         }}
       >
         <CardHeader
@@ -44,15 +48,25 @@ const TournamentCard: React.FC<TournamentCardProps> = ({
               {t("upcoming_tournament_view.tournament_full")}
             </Typography>
           )}
-          <Typography color="text.secondary">
-            {t("frontpage_labels.start_date")}:{" "}
-            {new Date(tournament.startDate).toLocaleDateString("fi")}
-          </Typography>
-
-          <Typography color="text.secondary">
-            {t("frontpage_labels.end_date")}:{" "}
-            {new Date(tournament.endDate).toLocaleDateString("fi")}
-          </Typography>
+          {(type === "ongoing" || type === "upcoming") && (
+            <Typography color="text.secondary">
+              {t("frontpage_labels.start_date")}:{" "}
+              {new Date(tournament.startDate).toLocaleDateString("fi")}
+            </Typography>
+          )}
+          {(type === "ongoing" || type === "upcoming") && (
+            <Typography color="text.secondary">
+              {t("frontpage_labels.end_date")}:{" "}
+              {new Date(tournament.endDate).toLocaleDateString("fi")}
+            </Typography>
+          )}
+          {type === "past" && (
+            <Typography color="text.secondary">
+              {tournament.location},
+              {new Date(tournament.startDate).toLocaleDateString("fi")} -
+              {new Date(tournament.endDate).toLocaleDateString("fi")}
+            </Typography>
+          )}
         </CardContent>
       </CardActionArea>
       {type === "upcoming" && (

--- a/frontend/src/routes/Router.tsx
+++ b/frontend/src/routes/Router.tsx
@@ -15,6 +15,7 @@ import CreateTournamentForm from "components/modules/Tournaments/CreateTournamen
 import Signup from "components/modules/Tournaments/Signup/Signup";
 import TournamentDetails from "components/modules/Tournaments/TournamentDetails";
 import TournamentList from "components/modules/Tournaments/TournamentListing/TournamentsList";
+import PastTournamentMatches from "components/modules/Tournaments/PastTournamentMatches";
 import { TournamentsProvider } from "context/TournamentsContext";
 import { TournamentProvider } from "context/TournamentContext";
 import RootRoute from "./RootRoute";
@@ -28,6 +29,11 @@ const routes = createRoutesFromElements(
     <Route element={<Layout />}>
       <Route path={routePaths.tournaments} element={<TournamentsProvider />}>
         <Route index element={<TournamentList />} />
+
+        <Route
+          path="past-tournament/:tournamentId"
+          element={<PastTournamentMatches />}
+        />
 
         <Route element={<AuthenticationGuard />}>
           <Route path="new-tournament" element={<CreateTournamentForm />} />


### PR DESCRIPTION
Add sorting possibility for past tournaments tab. Also once a past tournament is clicked, shows a list of matches for that tournament. Currently scores for ties are not yet calculated, need to be added later once logic works.