### PR TITLE
Fix/playoff tie

### DIFF
--- a/backend/server/src/controllers/matchController.ts
+++ b/backend/server/src/controllers/matchController.ts
@@ -185,6 +185,8 @@ export class MatchController extends Controller {
   public async checkForTie(@Path() matchId: ObjectIdString): Promise<void> {
     this.setStatus(204);
 
-    await this.service.checkForTie(matchId);
+    const match = await this.service.checkForTie(matchId);
+
+    io.to(matchId).emit("check-tie", match);
   }
 }

--- a/backend/server/src/models/matchModel.ts
+++ b/backend/server/src/models/matchModel.ts
@@ -32,6 +32,7 @@ export interface Match {
   timeKeeper?: Types.ObjectId;
   pointMaker?: Types.ObjectId;
   isTimerOn: boolean;
+  isOvertime: boolean;
 }
 
 const pointSchema = new Schema<MatchPoint>(
@@ -90,7 +91,8 @@ const matchSchema = new Schema<Match>(
     },
     timeKeeper: { type: Schema.Types.ObjectId, required: false },
     pointMaker: { type: Schema.Types.ObjectId, required: false },
-    isTimerOn: { type: Boolean, required: true, default: false }
+    isTimerOn: { type: Boolean, required: true, default: false },
+    isOvertime: { type: Boolean, required: true, default: false }
   },
   {
     toObject: {

--- a/backend/server/src/services/matchService.ts
+++ b/backend/server/src/services/matchService.ts
@@ -289,11 +289,14 @@ export class MatchService {
       // When time ends, the player with more points wins
       // (rounded down because one hansoku doesn't count)
       if (
-        Math.floor(player1CalculatedScore) > Math.floor(player2CalculatedScore)
-       ||
+        Math.floor(player1CalculatedScore) >
+          Math.floor(player2CalculatedScore) ||
         Math.floor(player2CalculatedScore) > Math.floor(player1CalculatedScore)
       ) {
-        match.winner = player1CalculatedScore > player2CalculatedScore ? player1.id : player2.id;
+        match.winner =
+          player1CalculatedScore > player2CalculatedScore
+            ? player1.id
+            : player2.id;
         match.endTimestamp = new Date();
         if (match.type === "playoff") {
           await this.createPlayoffSchedule(match.id, match.winner);
@@ -303,7 +306,7 @@ export class MatchService {
         if (match.type === "group") {
           match.endTimestamp = new Date();
           await match.save();
-        } 
+        }
         // If it's a playoff, an overtime will start
         else if (
           match.type === "playoff" &&
@@ -313,7 +316,7 @@ export class MatchService {
           await match.save();
         }
       }
-      
+
       match.player1Score = Math.floor(player1CalculatedScore);
       match.player2Score = Math.floor(player2CalculatedScore);
 
@@ -331,9 +334,15 @@ export class MatchService {
       this.calculateScore(player1.points, player2.points);
 
     // Check if player 1 or 2 has 2 points and wins
-    if (player1CalculatedScore >= MAXIMUM_POINTS || player2CalculatedScore >= MAXIMUM_POINTS) {
+    if (
+      player1CalculatedScore >= MAXIMUM_POINTS ||
+      player2CalculatedScore >= MAXIMUM_POINTS
+    ) {
       // Determine the winner based on points
-      match.winner = player1CalculatedScore > player2CalculatedScore ? player1.id : player2.id;
+      match.winner =
+        player1CalculatedScore > player2CalculatedScore
+          ? player1.id
+          : player2.id;
       match.endTimestamp = new Date();
 
       if (match.type === "playoff") {

--- a/backend/server/src/services/matchService.ts
+++ b/backend/server/src/services/matchService.ts
@@ -289,7 +289,6 @@ export class MatchService {
       // When time ends, the player with more points wins
       // (rounded down because one hansoku doesn't count)
       if (
-        
         Math.floor(player1CalculatedScore) > Math.floor(player2CalculatedScore)
        ||
         Math.floor(player2CalculatedScore) > Math.floor(player1CalculatedScore)
@@ -300,10 +299,13 @@ export class MatchService {
           await this.createPlayoffSchedule(match.id, match.winner);
         }
       } else {
+        // If the points are the same, it's a tie (in round robin)
         if (match.type === "group") {
           match.endTimestamp = new Date();
           await match.save();
-        } else if (
+        } 
+        // If it's a playoff, an overtime will start
+        else if (
           match.type === "playoff" &&
           player1CalculatedScore === player2CalculatedScore
         ) {
@@ -311,6 +313,9 @@ export class MatchService {
           await match.save();
         }
       }
+      
+      match.player1Score = Math.floor(player1CalculatedScore);
+      match.player2Score = Math.floor(player2CalculatedScore);
 
       await match.save();
     }

--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -30,6 +30,7 @@
     "player": "Player",
     "wins": "wins!",
     "dialog_title": "Select a point",
+    "overtime": "OVERTIME:",
     "point_types": {
       "men": "Men",
       "kote": "Kote",

--- a/frontend/locales/fi.json
+++ b/frontend/locales/fi.json
@@ -30,6 +30,7 @@
     "player": "Pelaaja",
     "wins": "voittaa!",
     "dialog_title": "Valitse piste",
+    "overtime": "JATKOAIKA:",
     "point_types": {
       "men": "Men",
       "kote": "Kote",

--- a/frontend/src/components/modules/GameInterface/GameInterface.tsx
+++ b/frontend/src/components/modules/GameInterface/GameInterface.tsx
@@ -17,7 +17,13 @@ import TimerButton from "./TimerButton";
 import api from "api/axios";
 import { useParams } from "react-router-dom";
 import { type AddPointRequest } from "types/requests";
-import type { PointType, PlayerColor, Match, MatchPlayer, MatchType } from "types/models";
+import type {
+  PointType,
+  PlayerColor,
+  Match,
+  MatchPlayer,
+  MatchType
+} from "types/models";
 import "./GameInterface.css";
 import { useAuth } from "context/AuthContext";
 import { joinMatch, leaveMatch } from "sockets/emit";
@@ -67,7 +73,9 @@ const GameInterface: React.FC = () => {
   const [openRoles, setOpenRoles] = useState(false);
   const [selectedButton, setSelectedButton] = useState<string>("");
   const [timer, setTimer] = useState<number>(matchInfo.timerTime);
-  const [overtimeTimer, setOvertimeTimer] = useState<number>(Math.floor(matchInfo.elapsedTime / 1000) - MATCH_TIME /1000);
+  const [overtimeTimer, setOvertimeTimer] = useState<number>(
+    Math.floor(matchInfo.elapsedTime / 1000) - MATCH_TIME / 1000
+  );
   const [playerColor, setPlayerColor] = useState<PlayerColor>("red");
   const [hasJoined, setHasJoined] = useState(false);
 
@@ -81,7 +89,6 @@ const GameInterface: React.FC = () => {
   // state handlers for whether or not checkbox is checked
   const [timeKeeper, setTimeKeeper] = useState<boolean>(false);
   const [pointMaker, setPointMaker] = useState<boolean>(false);
-
 
   // Listening to matches websocket
   useEffect(() => {
@@ -248,7 +255,9 @@ const GameInterface: React.FC = () => {
 
   useEffect(() => {
     if (matchInfo.isOvertime) {
-      setOvertimeTimer(Math.floor(matchInfo.elapsedTime / 1000) - MATCH_TIME /1000);
+      setOvertimeTimer(
+        Math.floor(matchInfo.elapsedTime / 1000) - MATCH_TIME / 1000
+      );
     } else {
       setTimer(matchInfo.timerTime);
     }
@@ -295,7 +304,7 @@ const GameInterface: React.FC = () => {
         if (
           (matchInfo.elapsedTime >= MATCH_TIME ||
             matchInfo.endTimeStamp !== undefined) &&
-            matchId !== undefined
+          matchId !== undefined
         ) {
           await api.match.checkForTie(matchId);
         }
@@ -592,20 +601,18 @@ const GameInterface: React.FC = () => {
             </Box>
             {matchInfo.isOvertime && (
               <Box display="flex" gap="20px" justifyContent="center">
-                <Typography variant="body2">{t("game_interface.overtime")}</Typography>
+                <Typography variant="body2">
+                  {t("game_interface.overtime")}
+                </Typography>
               </Box>
             )}
             <Box display="flex" gap="20px" justifyContent="center">
-              {matchInfo.isOvertime && (
-                <Timer timer={overtimeTimer} />
-              )}
-              {!matchInfo.isOvertime && (
-                <Timer timer={timer} />
-              )}
+              {matchInfo.isOvertime && <Timer timer={overtimeTimer} />}
+              {!matchInfo.isOvertime && <Timer timer={timer} />}
               {/* timer button only shown to time keeper */}
               {userId !== null &&
                 userId !== undefined &&
-                showButtons() !== false &&
+                showButtons() &&
                 matchInfo.timeKeeper === userId && (
                   <TimerButton
                     isTimerRunning={matchInfo.isTimerOn}
@@ -618,7 +625,7 @@ const GameInterface: React.FC = () => {
             {/* point buttons only shown to point maker */}
             {userId !== null &&
               userId !== undefined &&
-              showButtons() !== false &&
+              showButtons() &&
               matchInfo.pointMaker === userId && (
                 <OfficialButtons
                   open={openPoints}
@@ -642,7 +649,8 @@ const GameInterface: React.FC = () => {
             {/* If there isn't a winner, check if there is an end timestamp (it's a tie) */}
             {matchInfo.winner === undefined &&
               (matchInfo.endTimeStamp !== undefined ||
-                (matchInfo.elapsedTime >= MATCH_TIME && matchInfo.type !== "playoff")) && (
+                (matchInfo.elapsedTime >= MATCH_TIME &&
+                  matchInfo.type !== "playoff")) && (
                 <div>
                   <Typography>{t("game_interface.tie")}</Typography>
                 </div>

--- a/frontend/src/components/modules/GameInterface/GameInterface.tsx
+++ b/frontend/src/components/modules/GameInterface/GameInterface.tsx
@@ -17,7 +17,7 @@ import TimerButton from "./TimerButton";
 import api from "api/axios";
 import { useParams } from "react-router-dom";
 import { type AddPointRequest } from "types/requests";
-import type { PointType, PlayerColor, Match, MatchPlayer } from "types/models";
+import type { PointType, PlayerColor, Match, MatchPlayer, MatchType } from "types/models";
 import "./GameInterface.css";
 import { useAuth } from "context/AuthContext";
 import { joinMatch, leaveMatch } from "sockets/emit";
@@ -39,6 +39,8 @@ export interface MatchData {
   startTimestamp: Date | undefined;
   isTimerOn: boolean;
   elapsedTime: number;
+  isOvertime: boolean;
+  type: MatchType;
 }
 
 const GameInterface: React.FC = () => {
@@ -54,13 +56,18 @@ const GameInterface: React.FC = () => {
     pointMaker: undefined,
     startTimestamp: undefined,
     isTimerOn: false,
-    elapsedTime: 0
+    elapsedTime: 0,
+    isOvertime: false,
+    type: "group"
   });
 
+  // to be changed when match time is get from api
+  const MATCH_TIME = 300000;
   const [openPoints, setOpenPoints] = useState(false);
   const [openRoles, setOpenRoles] = useState(false);
   const [selectedButton, setSelectedButton] = useState<string>("");
   const [timer, setTimer] = useState<number>(matchInfo.timerTime);
+  const [overtimeTimer, setOvertimeTimer] = useState<number>(Math.floor(matchInfo.elapsedTime / 1000) - MATCH_TIME /1000);
   const [playerColor, setPlayerColor] = useState<PlayerColor>("red");
   const [hasJoined, setHasJoined] = useState(false);
 
@@ -74,8 +81,7 @@ const GameInterface: React.FC = () => {
   // state handlers for whether or not checkbox is checked
   const [timeKeeper, setTimeKeeper] = useState<boolean>(false);
   const [pointMaker, setPointMaker] = useState<boolean>(false);
-  // to be changed when match time is get from api
-  const MATCH_TIME = 300000;
+
 
   // Listening to matches websocket
   useEffect(() => {
@@ -104,6 +110,8 @@ const GameInterface: React.FC = () => {
         let startTime: Date | undefined;
         let timer: boolean = false;
         let elapsedtime: number = 0;
+        let isovertime: boolean = false;
+        let matchType: MatchType = "group";
 
         // Get players' names
         const findPlayerName = (playerId: string, index: number): void => {
@@ -155,6 +163,8 @@ const GameInterface: React.FC = () => {
           timer = matchInfoFromSocket.isTimerOn;
 
           elapsedtime = matchInfoFromSocket.elapsedTime;
+          isovertime = matchInfoFromSocket.isOvertime;
+          matchType = matchInfoFromSocket.type;
 
           setTimeKeeper(matchInfoFromSocket.timeKeeper !== undefined);
           setPointMaker(matchInfoFromSocket.pointMaker !== undefined);
@@ -205,6 +215,8 @@ const GameInterface: React.FC = () => {
             timer = matchFromApi.isTimerOn;
 
             elapsedtime = matchFromApi.elapsedTime;
+            isovertime = matchFromApi.isOvertime;
+            matchType = matchFromApi.type;
 
             setTimeKeeper(matchInfo.timeKeeper !== undefined);
             setPointMaker(matchInfo.pointMaker !== undefined);
@@ -220,7 +232,9 @@ const GameInterface: React.FC = () => {
           pointMaker: pointPerson,
           startTimestamp: startTime,
           isTimerOn: timer,
-          elapsedTime: elapsedtime
+          elapsedTime: elapsedtime,
+          isOvertime: isovertime,
+          type: matchType
         });
       } catch (error) {
         setIsError(true);
@@ -233,8 +247,12 @@ const GameInterface: React.FC = () => {
   }, [isLoading, matchInfoFromSocket]);
 
   useEffect(() => {
-    setTimer(matchInfo.timerTime);
-  }, [matchInfo]);
+    if (matchInfo.isOvertime) {
+      setOvertimeTimer(Math.floor(matchInfo.elapsedTime / 1000) - MATCH_TIME /1000);
+    } else {
+      setTimer(matchInfo.timerTime);
+    }
+  }, [matchInfo.isOvertime, matchInfo.elapsedTime, matchInfo.timerTime]);
 
   // Handle timer, make it run and stop
   useEffect(() => {
@@ -242,7 +260,11 @@ const GameInterface: React.FC = () => {
 
     if (matchInfo.isTimerOn) {
       intervalId = setInterval(() => {
-        setTimer((prevTimer) => (prevTimer > 0 ? prevTimer - 1 : 0));
+        if (matchInfo.isOvertime) {
+          setOvertimeTimer((prevTime) => prevTime + 1);
+        } else {
+          setTimer((prevTimer) => (prevTimer > 0 ? prevTimer - 1 : 0));
+        }
       }, 1000);
     } else {
       if (intervalId !== null) {
@@ -255,22 +277,25 @@ const GameInterface: React.FC = () => {
         clearInterval(intervalId);
       }
     };
-  }, [matchInfo]);
+  }, [matchInfo.isTimerOn, matchInfo.isOvertime]);
 
   // If timer is ended, check for ties
   useEffect(() => {
     const checkForTieAndStopTimer = async (): Promise<void> => {
       try {
-        if (timer === 0 && matchId !== undefined) {
+        if (matchInfo.winner !== undefined) {
+          return; // Exit early if the winner has been determined so no endless rerendering
+        }
+
+        if (timer === 0 && matchId !== undefined && !matchInfo.isOvertime) {
           if (matchInfo.isTimerOn) {
             await apiTimerRequest(matchId);
           }
         }
-
         if (
           (matchInfo.elapsedTime >= MATCH_TIME ||
             matchInfo.endTimeStamp !== undefined) &&
-          matchId !== undefined
+            matchId !== undefined
         ) {
           await api.match.checkForTie(matchId);
         }
@@ -317,7 +342,12 @@ const GameInterface: React.FC = () => {
       if (matchInfo.isTimerOn) {
         await apiTimerRequest(matchId);
       }
-      await apiPointRequest(matchId, pointRequest);
+      if (matchInfo.isOvertime) {
+        await apiPointRequest(matchId, pointRequest);
+        await api.match.checkForTie(matchId);
+      } else {
+        await apiPointRequest(matchId, pointRequest);
+      }
     }
   };
 
@@ -434,7 +464,8 @@ const GameInterface: React.FC = () => {
       return false;
     } else if (
       matchInfo.winner === undefined &&
-      matchInfo.elapsedTime > MATCH_TIME
+      matchInfo.elapsedTime > MATCH_TIME &&
+      matchInfo.type === "group"
     ) {
       return false;
     } else {
@@ -559,12 +590,22 @@ const GameInterface: React.FC = () => {
                 <Typography variant="h3">{matchInfo.playerNames[1]}</Typography>
               </Box>
             </Box>
+            {matchInfo.isOvertime && (
+              <Box display="flex" gap="20px" justifyContent="center">
+                <Typography variant="body2">{t("game_interface.overtime")}</Typography>
+              </Box>
+            )}
             <Box display="flex" gap="20px" justifyContent="center">
-              <Timer timer={timer} />
+              {matchInfo.isOvertime && (
+                <Timer timer={overtimeTimer} />
+              )}
+              {!matchInfo.isOvertime && (
+                <Timer timer={timer} />
+              )}
               {/* timer button only shown to time keeper */}
               {userId !== null &&
                 userId !== undefined &&
-                showButtons() &&
+                showButtons() !== false &&
                 matchInfo.timeKeeper === userId && (
                   <TimerButton
                     isTimerRunning={matchInfo.isTimerOn}
@@ -577,7 +618,7 @@ const GameInterface: React.FC = () => {
             {/* point buttons only shown to point maker */}
             {userId !== null &&
               userId !== undefined &&
-              showButtons() &&
+              showButtons() !== false &&
               matchInfo.pointMaker === userId && (
                 <OfficialButtons
                   open={openPoints}
@@ -601,7 +642,7 @@ const GameInterface: React.FC = () => {
             {/* If there isn't a winner, check if there is an end timestamp (it's a tie) */}
             {matchInfo.winner === undefined &&
               (matchInfo.endTimeStamp !== undefined ||
-                matchInfo.elapsedTime >= MATCH_TIME) && (
+                (matchInfo.elapsedTime >= MATCH_TIME && matchInfo.type !== "playoff")) && (
                 <div>
                   <Typography>{t("game_interface.tie")}</Typography>
                 </div>

--- a/frontend/src/sockets/events.ts
+++ b/frontend/src/sockets/events.ts
@@ -47,4 +47,10 @@ export const socketEvents = (
       return { ...state, matchInfo };
     });
   });
+
+  socket.on("check-tie", (matchInfo: Match) => {
+    setValue((state) => {
+      return { ...state, matchInfo };
+    });
+  });
 };

--- a/frontend/src/types/models.ts
+++ b/frontend/src/types/models.ts
@@ -47,6 +47,7 @@ export interface Match {
   timeKeeper?: string;
   pointMaker?: string;
   isTimerOn: boolean;
+  isOvertime: boolean;
 }
 
 export interface Tournament {


### PR DESCRIPTION
add handling for playoff ties so going into overtime. now if its a playoff match ending in a tie, the buttons dont disappear and the option to add a point stays available. match ends after someone scores a point
- new timer for overtime with variable
- refactoring match outcome checking
- print to tell that the match has gone into overtime