### PR TITLE
Fixes/playoff UI

### DIFF
--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -195,7 +195,7 @@
     "mostRecent": "Most recent",
     "oldest": "Oldest",
     "name": "Name A-Ö",
-    "nameDesc": "Name Ö-Ä",
+    "nameDesc": "Name Ö-A",
     "location": "Location"
   },
   "terms_and_conditions": {

--- a/frontend/locales/fi.json
+++ b/frontend/locales/fi.json
@@ -131,7 +131,7 @@
     "sign_up_for": "Ilmoittaudu: ",
     "want_more_info": "Haluatko lisätietoja tästä turnauksesta?",
     "click_here": "Klikkaa tästä",
-    "userInfo": "Ilmoittautumisen yhteydessä annettavat tiedot:",
+    "user_info": "Ilmoittautumisen yhteydessä annettavat tiedot:",
     "user_info_table": "Käyttäjätiedot",
     "player_table": "Pelaajataulu"
   },
@@ -196,7 +196,7 @@
     "mostRecent": "Uusin",
     "oldest": "Vanhin",
     "name": "Nimi A-Ö",
-    "nameDesc": "Nimi Ö-Ä",
+    "nameDesc": "Nimi Ö-A",
     "location": "Sijainti"
   },
   "terms_and_conditions": {

--- a/frontend/src/components/modules/Tournaments/OngoingTournament/TournamentBracket.tsx
+++ b/frontend/src/components/modules/Tournaments/OngoingTournament/TournamentBracket.tsx
@@ -33,12 +33,22 @@ const Bracket: React.FC<BracketProps> = ({ match, players }) => {
   const player1Name = `${player1.firstName} ${player1.lastName}`;
   const player2Name = `${player2.firstName} ${player2.lastName}`;
 
+  let player1Font = "regular";
+  let player2Font = "regular";
   let player1Color = "black";
   let player2Color = "black";
+  let player1Lining = "";
+  let player2Lining = "";
 
   if (isWinnerDeclared) {
-    player1Color = winner === player1.id ? "#f44336" : "#666666";
-    player2Color = winner === player2.id ? "#f44336" : "#666666";
+    player1Font = winner === player1.id ? "700" : "regular";
+    player2Font = winner === player2.id ? "700" : "regular";
+
+    player1Color = winner === player1.id ? "black" : "#666666";
+    player2Color = winner === player2.id ? "black" : "#666666";
+
+    player1Lining = winner === player1.id ? "underline" : "";
+    player2Lining = winner === player2.id ? "underline" : "";
   }
 
   const officialsInfo = [];
@@ -81,11 +91,25 @@ const Bracket: React.FC<BracketProps> = ({ match, players }) => {
           }}
         >
           <CardContent>
-            <Typography textAlign="center" style={{ color: player1Color }}>
+            <Typography
+              textAlign="center"
+              style={{
+                fontWeight: player1Font,
+                color: player1Color,
+                textDecoration: player1Lining
+              }}
+            >
               {player1Name}
             </Typography>
             <Typography textAlign="center"> vs</Typography>
-            <Typography textAlign="center" style={{ color: player2Color }}>
+            <Typography
+              textAlign="center"
+              style={{
+                fontWeight: player2Font,
+                color: player2Color,
+                textDecoration: player2Lining
+              }}
+            >
               {player2Name}
             </Typography>
             {match.elapsedTime <= 0 &&

--- a/frontend/src/components/modules/Tournaments/OngoingTournament/TournamentBracket.tsx
+++ b/frontend/src/components/modules/Tournaments/OngoingTournament/TournamentBracket.tsx
@@ -114,11 +114,23 @@ const Bracket: React.FC<BracketProps> = ({ match, players }) => {
             </Typography>
             {isWinnerDeclared && (
               <Typography textAlign="center" variant="h6">
-                <span style={{ color: player1Color }}>
+                <span
+                  style={{
+                    fontWeight: player1Font,
+                    color: player1Color,
+                    textDecoration: player1Lining
+                  }}
+                >
                   {match.player1Score}
                 </span>{" "}
                 -{" "}
-                <span style={{ color: player2Color }}>
+                <span
+                  style={{
+                    fontWeight: player2Font,
+                    color: player2Color,
+                    textDecoration: player2Lining
+                  }}
+                >
                   {match.player2Score}
                 </span>
               </Typography>


### PR DESCRIPTION
Change UI in finished matches in playoff view to be more accessible by not changing the winner's name's color but bolding and underlining it. Also small bug fixes in locales.
Before:
![image](https://github.com/Kendoers/Kendo-tournament-app/assets/145121433/9c2e329e-b290-47b6-a1bf-9b302193df06)
After:
![image](https://github.com/Kendoers/Kendo-tournament-app/assets/145121433/593761da-57c1-4e3f-b891-a66a7c73f62a)
