### PR TITLE
Create view for created tournaments' details

### DIFF
--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -156,6 +156,19 @@
     "start_date": "Start Date",
     "end_date": "End Date"
   },
+  "created_tournament": {
+    "signed_up": "Signed up",
+    "no_players_signed_up": "No players have signed up yet.",
+    "location_header": "Where",
+    "date_header": "When",
+    "description": "About the Tournament",
+    "category_header": "Tournament category",
+    "type_header": "Type of Tournament",
+    "link_to_site_header": "Organizer's website",
+    "link_to_payment_header": "Link to payment site",
+    "match_time": "Match time",
+    "max_players": "Maximum number of players"
+  },
   "create_tournament_form": {
     "info": "Fill information below.",
     "tournament_name": "Tournament Name",
@@ -327,8 +340,8 @@
     "my_games": "My games",
     "my_points": "My points",
     "point_type": "Point type",
-    "points": "Points"
-    
+    "points": "Points",
+    "created_tournaments": "Created tournaments"
   }
 
 }

--- a/frontend/locales/fi.json
+++ b/frontend/locales/fi.json
@@ -156,6 +156,19 @@
     "start_date": "Aloituspäivä",
     "end_date": "Päättymispäivä"
   },
+  "created_tournament": {
+    "signed_up": "Ilmottautuneet",
+    "no_players_signed_up": "Pelaajia ei ole vielä ilmottautunut.",
+    "location_header": "Missä",
+    "date_header": "Milloin",
+    "description": "Turnauksesta",
+    "category_header": "Turnauksen kategoria",
+    "type_header": "Turnauksen tyyppi",
+    "link_to_site_header": "Järjestäjän sivut",
+    "link_to_payment_header": "Linkki maksusivustolle",
+    "match_time": "Ottelun pituus",
+    "max_players": "Pelaajien enimmäismäärä"
+  },
   "create_tournament_form": {
     "info": "Täytä alla olevat kentät",
     "tournament_name": "Turnauksen nimi",
@@ -327,6 +340,7 @@
     "my_games": "Omat ottelut",
     "my_points": "Omat pisteet",
     "point_type": "Pistetyyppi",
-    "points": "Pisteet"
+    "points": "Pisteet",
+    "created_tournaments": "Luodut turnaukset"
   }
 }

--- a/frontend/src/components/modules/Profile/CreatedTournaments.tsx
+++ b/frontend/src/components/modules/Profile/CreatedTournaments.tsx
@@ -1,0 +1,97 @@
+import React, { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  Typography,
+  Card,
+  CardContent,
+  CardActionArea,
+  Box
+} from "@mui/material";
+import { useAuth } from "context/AuthContext";
+import api from "api/axios";
+import type { Tournament } from "types/models";
+
+const CreatedTournaments: React.FC = () => {
+  const navigate = useNavigate();
+  const { userId } = useAuth();
+
+  // State for storing the user's created tournaments
+  const [tournaments, setTournaments] = useState<Tournament[]>([]);
+
+  useEffect(() => {
+    const fetchTournaments = async (): Promise<void> => {
+      try {
+        const tournamentsData = await api.tournaments.getAll();
+        // Filter tournaments to include only those created by the current user
+        const filteredTournaments = tournamentsData.filter(
+          (tournament) => tournament.creator.id === userId
+        );
+        // Sort tournaments based on startDate
+        filteredTournaments.sort(
+          (a, b) =>
+            new Date(b.startDate).getTime() - new Date(a.startDate).getTime()
+        );
+        // Update state with filtered and sorted tournaments
+        setTournaments(filteredTournaments);
+      } catch (error) {
+        // Error handling can be added here if necessary
+      }
+    };
+
+    void fetchTournaments();
+  }, [userId]);
+
+  return (
+    <Box>
+      {tournaments.map((tournament, index) => (
+        <Card key={index} style={{ marginBottom: "20px" }}>
+          <CardActionArea
+            onClick={() => {
+              navigate(`/tournaments/participants/${tournament.id}`);
+              console.log("Painoit turnauksen painiketta:", tournament.name);
+              console.log("id:", tournament.id);
+            }}
+          >
+            <CardContent>
+              {/* Display tournament name and start/end dates */}
+              <Typography variant="h5" sx={{ marginBottom: 4, marginTop: 4 }}>
+                {tournament.name}
+                <Typography
+                  component="span"
+                  variant="subtitle1"
+                  sx={{ display: "inline", marginLeft: 1 }}
+                >
+                  {new Date(tournament.startDate).toLocaleDateString("en-US", {
+                    day: "2-digit",
+                    month: "2-digit",
+                    year: "numeric"
+                  })}
+                  {new Date(tournament.startDate).toLocaleDateString("en-US", {
+                    day: "2-digit",
+                    month: "2-digit",
+                    year: "numeric"
+                  }) !==
+                    new Date(tournament.endDate).toLocaleDateString("en-US", {
+                      day: "2-digit",
+                      month: "2-digit",
+                      year: "numeric"
+                    }) &&
+                    ` - ${new Date(tournament.endDate).toLocaleDateString(
+                      "en-US",
+                      {
+                        day: "2-digit",
+                        month: "2-digit",
+                        year: "numeric"
+                      }
+                    )}`}
+                </Typography>
+              </Typography>
+            </CardContent>
+          </CardActionArea>
+        </Card>
+      ))}
+    </Box>
+  );
+};
+
+export default CreatedTournaments;

--- a/frontend/src/components/modules/Profile/CreatedTournaments.tsx
+++ b/frontend/src/components/modules/Profile/CreatedTournaments.tsx
@@ -47,9 +47,7 @@ const CreatedTournaments: React.FC = () => {
         <Card key={index} style={{ marginBottom: "20px" }}>
           <CardActionArea
             onClick={() => {
-              navigate(`/tournaments/participants/${tournament.id}`);
-              console.log("Painoit turnauksen painiketta:", tournament.name);
-              console.log("id:", tournament.id);
+              navigate(`/tournaments/own-tournament/${tournament.id}`);
             }}
           >
             <CardContent>

--- a/frontend/src/components/modules/Profile/Profile.tsx
+++ b/frontend/src/components/modules/Profile/Profile.tsx
@@ -1,17 +1,39 @@
-import React, { Fragment, useState } from "react";
+import React, { Fragment, useState, useEffect } from "react";
 import ProfileInfo from "./ProfileInfo";
 import ProfileGames from "./ProfileGames";
 import ProfilePoints from "./ProfilePoints";
+import CreatedTournaments from "./CreatedTournaments";
 import Tabs from "@mui/material/Tabs";
 import Tab from "@mui/material/Tab";
 import { useTranslation } from "react-i18next";
 import { Box, Container, MenuItem, Select } from "@mui/material";
 import useMediaQuery from "@mui/material/useMediaQuery";
+import { useAuth } from "context/AuthContext";
+import api from "api/axios";
+import type { Tournament } from "types/models";
 
 const Profile: React.FC = () => {
   const [selectedTab, setSelectedTab] = useState("info");
+  const [userCreatedTournaments, setUserCreatedTournaments] = useState<
+    Tournament[]
+  >([]);
   const { t } = useTranslation();
   const mobile = useMediaQuery("(max-width:600px)");
+  const { userId } = useAuth();
+
+  useEffect(() => {
+    const fetchUserCreatedTournaments = async (): Promise<void> => {
+      try {
+        const tournamentsData = await api.tournaments.getAll();
+        const filteredTournaments = tournamentsData.filter(
+          (tournament) => tournament.creator.id === userId
+        );
+        setUserCreatedTournaments(filteredTournaments);
+      } catch (error) {}
+    };
+
+    void fetchUserCreatedTournaments();
+  }, [userId]);
 
   const handleTabChange = (
     _event: React.ChangeEvent<unknown>,
@@ -40,6 +62,11 @@ const Profile: React.FC = () => {
             <MenuItem value="info">{t("profile.profile_info")}</MenuItem>
             <MenuItem value="games">{t("profile.my_games")}</MenuItem>
             <MenuItem value="points">{t("profile.my_points")}</MenuItem>
+            {userCreatedTournaments.length > 0 && (
+              <MenuItem value="created_t">
+                {t("profile.created_tournaments")}
+              </MenuItem>
+            )}
           </Select>
           <br></br>
         </Fragment>
@@ -53,12 +80,16 @@ const Profile: React.FC = () => {
             <Tab label={t("profile.profile_info")} value="info" />
             <Tab label={t("profile.my_games")} value="games" />
             <Tab label={t("profile.my_points")} value="points" />
+            {userCreatedTournaments.length > 0 && (
+              <Tab label={t("profile.created_tournaments")} value="created_t" />
+            )}
           </Tabs>
         </Box>
       )}
       {selectedTab === "info" && <ProfileInfo />}
       {selectedTab === "games" && <ProfileGames />}
       {selectedTab === "points" && <ProfilePoints />}
+      {selectedTab === "created_t" && <CreatedTournaments />}
     </Container>
   );
 };

--- a/frontend/src/components/modules/Tournaments/OwnTournament.tsx
+++ b/frontend/src/components/modules/Tournaments/OwnTournament.tsx
@@ -67,7 +67,7 @@ const generateTable = (
   );
 };
 
-const Participants: React.FC = () => {
+const OwnTournament: React.FC = () => {
   const { tournamentId } = useParams<{ tournamentId: string }>();
   const [tournament, setTournament] = useState<Tournament | undefined>();
   const { t } = useTranslation();
@@ -235,4 +235,4 @@ const Participants: React.FC = () => {
     );
 };
 
-export default Participants;
+export default OwnTournament;

--- a/frontend/src/components/modules/Tournaments/Participants.tsx
+++ b/frontend/src/components/modules/Tournaments/Participants.tsx
@@ -1,0 +1,238 @@
+import React, { useState, useEffect } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import api from "api/axios";
+import TableContainer from "@mui/material/TableContainer";
+import Table from "@mui/material/Table";
+import TableHead from "@mui/material/TableHead";
+import TableRow from "@mui/material/TableRow";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import { useTranslation } from "react-i18next";
+import Paper from "@mui/material/Paper";
+import Container from "@mui/material/Container";
+import Box from "@mui/material/Box";
+import { Grid, Link, Typography } from "@mui/material";
+import routePaths from "routes/route-paths";
+import { useAuth } from "context/AuthContext";
+import type { Category, Tournament, TournamentType } from "types/models";
+
+const generateTable = (
+  tournament: Tournament,
+  t: (key: string) => string
+): React.ReactNode => {
+  const tableHeaders = [
+    t("user_info_labels.name"),
+    t("user_info_labels.club"),
+    t("user_info_labels.email_address"),
+    t("user_info_labels.phone_number")
+  ] as const;
+
+  // Generate table with player information
+  return (
+    <TableContainer component={Paper}>
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            {tableHeaders.map((header) => (
+              <TableCell key={header} aria-label={`header-${header}`}>
+                <Typography variant="subtitle1" fontWeight="bold">
+                  {header}
+                </Typography>
+              </TableCell>
+            ))}
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {tournament.players.map((player, index) => (
+            <TableRow key={player.id} aria-label={`player-${index}`}>
+              <TableCell aria-label={`cell-name-${index}`}>
+                <Typography>
+                  {`${player.firstName} ${player.lastName}`}
+                </Typography>
+              </TableCell>
+              <TableCell aria-label={`cell-club-${index}`}>
+                <Typography>{player.clubName ?? "-"}</Typography>
+              </TableCell>
+              <TableCell aria-label={`cell-email-${index}`}>
+                <Typography>{player.email ?? "-"}</Typography>
+              </TableCell>
+              <TableCell aria-label={`cell-phone-${index}`}>
+                <Typography>{player.phoneNumber ?? "-"}</Typography>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+};
+
+const Participants: React.FC = () => {
+  const { tournamentId } = useParams<{ tournamentId: string }>();
+  const [tournament, setTournament] = useState<Tournament | undefined>();
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const { userId } = useAuth();
+
+  const getTypeTranslationKey = (type: TournamentType): string => {
+    switch (type) {
+      case "Round Robin":
+        return "types.round_robin";
+      case "Playoff":
+        return "types.playoff";
+      case "Preliminary Playoff":
+        return "types.preliminary_playoff";
+      default:
+        return "";
+    }
+  };
+
+  // Function to translate tournament category to key
+  const getCategoryTranslationKey = (type: Category): string => {
+    switch (type) {
+      case "championship":
+        return "create_tournament_form.championship";
+      case "hobby":
+        return "create_tournament_form.hobby";
+      case "league":
+        return "create_tournament_form.league";
+      default:
+        return "";
+    }
+  };
+
+  useEffect(() => {
+    const fetchTournaments = async (): Promise<void> => {
+      try {
+        const tournamentsData = await api.tournaments.getAll();
+        const foundTournament = tournamentsData.find(
+          (tournament) => tournament.id === tournamentId
+        );
+        if (foundTournament !== undefined) {
+          // Check if the current user is the creator of the tournament
+          const isUserTheCreator = foundTournament.creator.id === userId;
+          // If the current user is not the creator, redirect to home page
+          if (!isUserTheCreator) {
+            navigate(routePaths.homeRoute);
+          }
+        }
+        setTournament(foundTournament ?? undefined);
+      } catch (error) {
+        // Error handling can be added here if necessary
+      }
+    };
+
+    void fetchTournaments();
+  }, [tournamentId]);
+
+  // Render tournament details if available
+  if (tournament !== undefined)
+    return (
+      <Container
+        component="main"
+        sx={{ display: "flex", flexDirection: "column", gap: "8px" }}
+      >
+        <Grid container alignItems="center" spacing={4}>
+          <Grid item>
+            <Typography
+              variant="h4"
+              className="header"
+              fontWeight="bold"
+              marginBottom="12px"
+            >
+              {tournament.name}
+            </Typography>
+          </Grid>
+        </Grid>
+        <Box>
+          <Typography variant="subtitle1">
+            <strong>{t("created_tournament.location_header")}:</strong>{" "}
+            {tournament.location}
+          </Typography>
+        </Box>
+        <Box>
+          <Typography variant="subtitle1">
+            <strong>{t("created_tournament.date_header")}:</strong>{" "}
+            {new Date(tournament.startDate).toLocaleString("fi")} -{" "}
+            {new Date(tournament.endDate).toLocaleString("fi")}
+          </Typography>
+        </Box>
+        <Box>
+          <Typography variant="subtitle1">
+            <strong>{t("created_tournament.description")}:</strong>{" "}
+            {tournament.description}
+          </Typography>
+        </Box>
+        {tournament.linkToSite !== undefined &&
+          tournament.linkToSite.trim() !== "" && (
+            <Box>
+              <Typography variant="subtitle1">
+                <strong>{t("created_tournament.link_to_site_header")}:</strong>{" "}
+                <Link href={tournament.linkToSite}>
+                  {tournament.linkToSite}
+                </Link>
+              </Typography>
+            </Box>
+          )}
+        {tournament.linkToPay !== undefined &&
+          tournament.linkToPay.trim() !== "" && (
+            <Box>
+              <Typography variant="subtitle1">
+                <strong>
+                  {t("created_tournament.link_to_payment_header")}:
+                </strong>{" "}
+                <Link href={tournament.linkToPay}>{tournament.linkToPay}</Link>
+              </Typography>
+            </Box>
+          )}
+        <Box>
+          <Typography variant="subtitle1">
+            <strong>{t("created_tournament.match_time")}:</strong>{" "}
+            {tournament.matchTime === 180000
+              ? t("create_tournament_form.3_min")
+              : tournament.matchTime === 240000
+              ? t("create_tournament_form.4_min")
+              : tournament.matchTime === 300000
+              ? t("create_tournament_form.5_min")
+              : ""}
+          </Typography>
+        </Box>
+        <Box>
+          <Typography variant="subtitle1">
+            <strong>{t("created_tournament.type_header")}:</strong>{" "}
+            {t(getTypeTranslationKey(tournament.type))}
+          </Typography>
+        </Box>
+        <Box>
+          <Typography variant="subtitle1">
+            <strong>{t("created_tournament.category_header")}:</strong>{" "}
+            {t(getCategoryTranslationKey(tournament.category))}
+          </Typography>
+        </Box>
+        <Box>
+          <Typography variant="subtitle1">
+            <strong>{t("created_tournament.max_players")}: </strong>{" "}
+            {tournament.maxPlayers}
+          </Typography>
+        </Box>
+        <br />
+        {/* There are players in the tournament, generate table if user is logged in */}
+        {tournament.players.length > 0 && (
+          <React.Fragment>
+            <Typography variant="body1" className="header" fontWeight="bold">
+              {t("created_tournament.signed_up")}
+            </Typography>
+            {generateTable(tournament, t)}
+          </React.Fragment>
+        )}
+        {/* No players in the tournament */}
+        {tournament.players.length === 0 && (
+          <Typography variant="body1" className="header" fontWeight="bold">
+            {t("created_tournament.no_players_signed_up")}
+          </Typography>
+        )}
+      </Container>
+    );
+};
+
+export default Participants;

--- a/frontend/src/routes/Router.tsx
+++ b/frontend/src/routes/Router.tsx
@@ -25,7 +25,7 @@ import { SocketProvider } from "context/SocketContext";
 import GameInterface from "components/modules/GameInterface/GameInterface";
 import PasswordControl from "components/modules/PasswordControl/PasswordControl";
 import PrivacyPolicy from "components/modules/Legal/PrivacyPolicy";
-import Participants from "components/modules/Tournaments/Participants";
+import OwnTournament from "components/modules/Tournaments/OwnTournament";
 
 const routes = createRoutesFromElements(
   <Route element={<RootRoute />}>
@@ -42,7 +42,7 @@ const routes = createRoutesFromElements(
           <Route path="new-tournament" element={<CreateTournamentForm />} />
         </Route>
 
-        <Route path="participants/:tournamentId" element={<Participants />} />
+        <Route path="own-tournament/:tournamentId" element={<OwnTournament />} />
 
         <Route path=":id" element={<TournamentProvider />}>
           <Route index element={<TournamentDetails />} />

--- a/frontend/src/routes/Router.tsx
+++ b/frontend/src/routes/Router.tsx
@@ -25,6 +25,7 @@ import { SocketProvider } from "context/SocketContext";
 import GameInterface from "components/modules/GameInterface/GameInterface";
 import PasswordControl from "components/modules/PasswordControl/PasswordControl";
 import PrivacyPolicy from "components/modules/Legal/PrivacyPolicy";
+import Participants from "components/modules/Tournaments/Participants";
 
 const routes = createRoutesFromElements(
   <Route element={<RootRoute />}>
@@ -40,6 +41,8 @@ const routes = createRoutesFromElements(
         <Route element={<AuthenticationGuard />}>
           <Route path="new-tournament" element={<CreateTournamentForm />} />
         </Route>
+
+        <Route path="participants/:tournamentId" element={<Participants />} />
 
         <Route path=":id" element={<TournamentProvider />}>
           <Route index element={<TournamentDetails />} />

--- a/frontend/src/routes/Router.tsx
+++ b/frontend/src/routes/Router.tsx
@@ -42,7 +42,10 @@ const routes = createRoutesFromElements(
           <Route path="new-tournament" element={<CreateTournamentForm />} />
         </Route>
 
-        <Route path="own-tournament/:tournamentId" element={<OwnTournament />} />
+        <Route
+          path="own-tournament/:tournamentId"
+          element={<OwnTournament />}
+        />
 
         <Route path=":id" element={<TournamentProvider />}>
           <Route index element={<TournamentDetails />} />


### PR DESCRIPTION
When accessing the profile, if the logged-in user has created at least one tournament, a fourth tab will appear in the view. This tab allows the user to see information about the tournament and the players who have signed up for it. Additionally, the information cannot be accessed via URL unless the user is the creator of the tournament.