### PR TITLE
bugfix/header-rendering-twice

### DIFF
--- a/backend/server/package-lock.json
+++ b/backend/server/package-lock.json
@@ -2534,14 +2534,6 @@
         "node": "*"
       }
     },
-    "node_modules/esm": {
-      "version": "3.2.25",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/espree": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",

--- a/frontend/src/components/modules/Tournaments/OngoingTournament/Playoff/PlayoffTournamentView.tsx
+++ b/frontend/src/components/modules/Tournaments/OngoingTournament/Playoff/PlayoffTournamentView.tsx
@@ -28,6 +28,8 @@ const PlayoffTournamentView: React.FC = () => {
   const isUserTheCreator = tournament.creator.id === userId;
   const [hasJoined, setHasJoined] = useState(false);
 
+  const isPlayoff = tournament.type === "Playoff";
+
   const { tournamentData: socketData } = useSocket();
 
   const [tournamentData, setTournamentData] = useState<Tournament>(
@@ -134,14 +136,16 @@ const PlayoffTournamentView: React.FC = () => {
           "&::-webkit-scrollbar": { display: "none" }
         }}
       >
-        <Grid container alignItems="center" spacing={4}>
-          <Grid item>
-            <Typography variant="h4">{tournament.name}</Typography>
+        {isPlayoff && (
+          <Grid container alignItems="center" spacing={4}>
+            <Grid item>
+              <Typography variant="h4">{tournament.name}</Typography>
+            </Grid>
+            <Grid item>
+              <CopyToClipboardButton />
+            </Grid>
           </Grid>
-          <Grid item>
-            <CopyToClipboardButton />
-          </Grid>
-        </Grid>
+        )}
 
         <Grid
           container


### PR DESCRIPTION
fix name and share button to render only with playoff tournaments so that when rendering the PlayoffTournamentView in prem playoff type, they aren't printed again